### PR TITLE
Add support for Juju 1.

### DIFF
--- a/internal/juju/info.go
+++ b/internal/juju/info.go
@@ -15,6 +15,10 @@ import (
 // current active model is returned.
 func Info(controllerAddr, modelUUID string) (string, string, error) {
 	if controllerAddr != "" {
+		controllerAddr, err := chooseAddress([]string{controllerAddr})
+		if err != nil {
+			return "", "", fmt.Errorf("cannot connect to the Juju controller: %s", err)
+		}
 		return controllerAddr, modelUUID, nil
 	}
 

--- a/internal/juju/info_test.go
+++ b/internal/juju/info_test.go
@@ -86,15 +86,19 @@ func TestInfo(t *testing.T) {
 		expectedControllerAddr: serverURL.Host,
 		expectedModelUUID:      "uuid42",
 	}, {
+		about:          "invalid address from input",
+		controllerAddr: ":::",
+		expectedError:  errors.New("cannot connect to the Juju controller: dial tcp:"),
+	}, {
 		about:                  "success from input",
-		controllerAddr:         "1.2.3.4:4242",
+		controllerAddr:         serverURL.Host,
 		modelUUID:              "uuid42",
-		expectedControllerAddr: "1.2.3.4:4242",
+		expectedControllerAddr: serverURL.Host,
 		expectedModelUUID:      "uuid42",
 	}, {
 		about:                  "success from input: no model uuid",
-		controllerAddr:         "1.2.3.4:4242",
-		expectedControllerAddr: "1.2.3.4:4242",
+		controllerAddr:         serverURL.Host,
+		expectedControllerAddr: serverURL.Host,
 	}}
 
 	// Run the tests.

--- a/server/export_test.go
+++ b/server/export_test.go
@@ -3,4 +3,11 @@ package server
 var (
 	ConfigTemplate = configTemplate
 	MkColor        = mkColor
+
+	ControllerSrcTemplate  = controllerSrcTemplate
+	ModelSrcTemplate       = modelSrcTemplate
+	LegacyModelSrcTemplate = legacyModelSrcTemplate
+
+	JujuVersion       = jujuVersion
+	LegacyJujuVersion = legacyJujuVersion
 )


### PR DESCRIPTION
A legacy Juju environment can be proxied by specifying its address and the -juju1 flag.