### PR TITLE
Add -env flag

### DIFF
--- a/guiproxy.go
+++ b/guiproxy.go
@@ -82,8 +82,7 @@ func parseOptions() (*config, error) {
 		valid options:
 		- 'production' (default)
 		- 'staging'
-		- 'qa'
-		- 'none' (explicitly empty values)`)
+		- 'qa'`)
 	legacyJuju := flag.Bool("juju1", false, "connect to a Juju 1 model")
 	noColor := flag.Bool("nocolor", false, "do not use colors")
 	flag.Parse()

--- a/guiproxy.go
+++ b/guiproxy.go
@@ -52,7 +52,7 @@ func main() {
 	srv := server.New(server.Params{
 		ControllerAddr: controllerAddr,
 		ModelUUID:      modelUUID,
-		OriginAddr:     "http://localhost" + listenAddr,
+		OriginAddr:     "http://0.0.0.0" + listenAddr,
 		GUIURL:         options.guiURL,
 		GUIConfig:      options.guiConfig,
 		LegacyJuju:     options.legacyJuju,
@@ -61,7 +61,7 @@ func main() {
 
 	// Start the GUI proxy server.
 	log.Println("starting the server\n")
-	log.Printf("visit the GUI at http://localhost:%d/\n", options.port)
+	log.Printf("visit the GUI at http://0.0.0.0:%d/\n", options.port)
 	if err := http.ListenAndServe(listenAddr, srv); err != nil {
 		log.Fatalf("cannot start server: %s", err)
 	}
@@ -82,7 +82,8 @@ func parseOptions() (*config, error) {
 		valid options:
 		- 'production' (default)
 		- 'staging'
-		- 'qa'`)
+		- 'qa'
+		- 'none' (explicitly empty values)`)
 	legacyJuju := flag.Bool("juju1", false, "connect to a Juju 1 model")
 	noColor := flag.Bool("nocolor", false, "do not use colors")
 	flag.Parse()

--- a/guiproxy.go
+++ b/guiproxy.go
@@ -74,23 +74,21 @@ func parseOptions() (*config, error) {
 	guiAddr := flag.String("gui", defaultGUIAddr, "address on which the GUI in sandbox mode is listening")
 	controllerAddr := flag.String("controller", "", `controller address (defaults to the address of the current controller), for instance:
 		-controller jimm.jujucharms.com:443`)
-	modelUUID := flag.String("uuid", "", fmt.Sprintf("model uuid (defaults to the uuid of the current model)"))
-	guiConfig := flag.String("config", "", fmt.Sprintf(`override or extend fields in the GUI configuration, for instance:
+	modelUUID := flag.String("uuid", "", "model uuid (defaults to the uuid of the current model)")
+	guiConfig := flag.String("config", "", `override or extend fields in the GUI configuration, for instance:
 		-config gisf:true
-		-config 'gisf: true, charmstoreURL: "https://1.2.3.4/cs"'`))
-	environment := flag.String("env", "production", fmt.Sprintf(`select a pre-defined environment to run against.
+		-config 'gisf: true, charmstoreURL: "https://1.2.3.4/cs"'`)
+	environment := flag.String("env", "production", `select a pre-defined environment to run against.
 		valid options:
 		- 'production' (default)
 		- 'staging'
-		- 'qa'`))
+		- 'qa'
+		- 'none' (explicitly empty values)`)
 	legacyJuju := flag.Bool("juju1", false, "connect to a Juju 1 model")
 	noColor := flag.Bool("nocolor", false, "do not use colors")
 	flag.Parse()
 	if !strings.HasPrefix(*guiAddr, "http") {
 		*guiAddr = "http://" + *guiAddr
-	}
-	if !environments[*environment] {
-		return nil, fmt.Errorf("invalid environment: %s", *environment)
 	}
 	guiURL, err := url.Parse(*guiAddr)
 	if err != nil {
@@ -117,12 +115,6 @@ const (
 	defaultPort    = 8042
 	defaultGUIAddr = "http://localhost:6543"
 )
-
-var environments = map[string]bool{
-	"production": true,
-	"staging":    true,
-	"qa":         true,
-}
 
 // config holds the GUI proxy server configuration options.
 type config struct {

--- a/guiproxy.go
+++ b/guiproxy.go
@@ -44,7 +44,7 @@ func main() {
 	if options.legacyJuju {
 		log.Println("using Juju 1")
 	}
-	if options.customConfig {
+	if options.hasCustomConfig {
 		log.Println("GUI config has been customized")
 	}
 
@@ -99,15 +99,15 @@ func parseOptions() (*config, error) {
 		return nil, fmt.Errorf("cannot parse GUI config: %s", err)
 	}
 	return &config{
-		port:           *port,
-		guiURL:         guiURL,
-		controllerAddr: *controllerAddr,
-		modelUUID:      *modelUUID,
-		environment:    *environment,
-		guiConfig:      overrides,
-		customConfig:   len(*guiConfig) != 0,
-		legacyJuju:     *legacyJuju,
-		noColor:        *noColor,
+		port:            *port,
+		guiURL:          guiURL,
+		controllerAddr:  *controllerAddr,
+		modelUUID:       *modelUUID,
+		environment:     *environment,
+		guiConfig:       overrides,
+		hasCustomConfig: len(*guiConfig) != 0,
+		legacyJuju:      *legacyJuju,
+		noColor:         *noColor,
 	}, nil
 }
 
@@ -118,15 +118,15 @@ const (
 
 // config holds the GUI proxy server configuration options.
 type config struct {
-	port           int
-	guiURL         *url.URL
-	controllerAddr string
-	modelUUID      string
-	environment    string
-	guiConfig      map[string]interface{}
-	customConfig   bool
-	legacyJuju     bool
-	noColor        bool
+	port            int
+	guiURL          *url.URL
+	controllerAddr  string
+	modelUUID       string
+	environment     string
+	guiConfig       map[string]interface{}
+	hasCustomConfig bool
+	legacyJuju      bool
+	noColor         bool
 }
 
 // usage provides the command help and usage information.

--- a/internal/guiconfig/config.go
+++ b/internal/guiconfig/config.go
@@ -20,6 +20,7 @@ func environmentValues(url string) map[string]string {
 		"charmstoreURL":    url + "/charmstore/",
 		"plansURL":         url + "/plans/",
 		"termsURL":         url + "/terms/",
+		"identityURL":      url + "/identity/",
 	}
 }
 
@@ -54,6 +55,7 @@ func New(ctx Context, overrides map[string]interface{}) string {
 		"bundleServiceURL":         "https://api.jujucharms.com/bundleservice/",
 		"plansURL":                 "https://api.jujucharms.com/omnibus/",
 		"termsURL":                 "https://api.jujucharms.com/terms/",
+		"identityURL":              "https://api.jujucharms.com/identity/",
 		"interactiveLogin":         true,
 		"html5":                    true,
 		"container":                "#main",

--- a/internal/guiconfig/config.go
+++ b/internal/guiconfig/config.go
@@ -12,25 +12,29 @@ const (
 	separator = ","
 )
 
-var environments = map[string]map[string]string{
-	"production": map[string]string{
-		"charmstoreURL":    "https://api.jujucharms.com/charmstore/",
-		"bundleServiceURL": "https://api.jujucharms.com/bundleservice/",
-		"plansURL":         "https://api.jujucharms.com/omnibus/",
-		"termsURL":         "https://api.jujucharms.com/terms/",
-	},
-	"staging": map[string]string{
-		"charmstoreURL":    "https://api.staging.jujucharms.com/charmstore/",
-		"bundleServiceURL": "https://api.staging.jujucharms.com/bundleservice/",
-		"plansURL":         "https://api.staging.jujucharms.com/omnibus/",
-		"termsURL":         "https://api.staging.jujucharms.com/terms/",
-	},
-	"qa": map[string]string{
-		"charmstoreURL":    "https://api.jujugui.org/charmstore/",
-		"bundleServiceURL": "https://api.jujugui.org/bundleservice/",
-		"plansURL":         "https://api.jujugui.org/omnibus/",
-		"termsURL":         "https://api.jujugui.org/terms/",
-	},
+func environmentValues(url string) map[string]string {
+	url = strings.TrimRight(url, "/")
+	return map[string]string{
+		"bundleServiceURL": url + "/bundleservice/",
+		"charmstoreURL":    url + "/charmstore/",
+		"plansURL":         url + "/plans/",
+		"termsURL":         url + "/terms/",
+	}
+}
+
+func Environment(env string) (map[string]string, error) {
+	switch env {
+	case "production":
+		return environmentValues("https://api.jujucharms.com"), nil
+	case "staging":
+		return environmentValues("https://api.staging.jujucharms.com"), nil
+	case "qa":
+		return environmentValues("https://www.jujugui.org"), nil
+	case "none":
+		return map[string]string{}, nil
+	default:
+		return nil, fmt.Errorf("invalid environment: %q", env)
+	}
 }
 
 // New generates and returns the Juju GUI configuration file as a string, based
@@ -91,25 +95,33 @@ type Context struct {
 // `gisf: true; charmstoreURL: "https://1.2.3.4/cs"`.
 func ParseOverridesForEnv(env, v string) (map[string]interface{}, error) {
 	pairs := strings.Split(v, separator)
-	overrides := make(map[string]interface{}, len(pairs)+4)
-	for envKey, envValue := range environments[env] {
+	environment, err := Environment(env)
+	if err != nil {
+		return nil, err
+	}
+	overrides := make(map[string]interface{}, len(pairs)+len(environment))
+	for envKey, envValue := range environment {
 		overrides[envKey] = envValue
 	}
-	if v != "" {
-		for _, pair := range pairs {
-			pair = strings.TrimSpace(pair)
-			keyVal := strings.SplitN(pair, ":", 2)
-			if len(keyVal) != 2 {
-				return nil, fmt.Errorf("invalid key/value pair %q", pair)
-			}
-			key := strings.TrimSpace(keyVal[0])
-			val := strings.TrimSpace(keyVal[1])
-			var value json.RawMessage
-			if err := json.Unmarshal([]byte(val), &value); err != nil {
-				return nil, fmt.Errorf("invalid value for key %s: %v", key, err)
-			}
-			overrides[key] = &value
+	if v == "" {
+		if len(overrides) == 0 {
+			return nil, nil
 		}
+		return overrides, nil
+	}
+	for _, pair := range pairs {
+		pair = strings.TrimSpace(pair)
+		keyVal := strings.SplitN(pair, ":", 2)
+		if len(keyVal) != 2 {
+			return nil, fmt.Errorf("invalid key/value pair %q", pair)
+		}
+		key := strings.TrimSpace(keyVal[0])
+		val := strings.TrimSpace(keyVal[1])
+		var value json.RawMessage
+		if err := json.Unmarshal([]byte(val), &value); err != nil {
+			return nil, fmt.Errorf("invalid value for key %s: %v", key, err)
+		}
+		overrides[key] = &value
 	}
 	return overrides, nil
 }

--- a/internal/guiconfig/config.go
+++ b/internal/guiconfig/config.go
@@ -12,6 +12,7 @@ const (
 	separator = ","
 )
 
+// environmentValues appends URL paths to the base URL provided.
 func environmentValues(url string) map[string]string {
 	url = strings.TrimRight(url, "/")
 	return map[string]string{
@@ -22,19 +23,18 @@ func environmentValues(url string) map[string]string {
 	}
 }
 
-func Environment(env string) (map[string]string, error) {
+// Environment takes an environment name and returns default values for
+// services on that environment.
+func environment(env string) (map[string]string, error) {
 	switch env {
 	case "production":
-		return environmentValues("https://api.jujucharms.com"), nil
+		return nil, nil
 	case "staging":
 		return environmentValues("https://api.staging.jujucharms.com"), nil
 	case "qa":
 		return environmentValues("https://www.jujugui.org"), nil
-	case "none":
-		return map[string]string{}, nil
-	default:
-		return nil, fmt.Errorf("invalid environment: %q", env)
 	}
+	return nil, fmt.Errorf("invalid environment: %q", env)
 }
 
 // New generates and returns the Juju GUI configuration file as a string, based
@@ -94,13 +94,13 @@ type Context struct {
 // Accepted strings are like the following:
 // `gisf: true; charmstoreURL: "https://1.2.3.4/cs"`.
 func ParseOverridesForEnv(env, v string) (map[string]interface{}, error) {
-	pairs := strings.Split(v, separator)
-	environment, err := Environment(env)
+	envMap, err := environment(env)
 	if err != nil {
 		return nil, err
 	}
-	overrides := make(map[string]interface{}, len(pairs)+len(environment))
-	for envKey, envValue := range environment {
+	pairs := strings.Split(v, separator)
+	overrides := make(map[string]interface{}, len(pairs)+len(envMap))
+	for envKey, envValue := range envMap {
 		overrides[envKey] = envValue
 	}
 	if v == "" {

--- a/internal/guiconfig/config_test.go
+++ b/internal/guiconfig/config_test.go
@@ -98,6 +98,7 @@ var parseOverridesForEnvTests = []struct {
 		"charmstoreURL":    "https://api.staging.jujucharms.com/charmstore/",
 		"plansURL":         "https://api.staging.jujucharms.com/plans/",
 		"termsURL":         "https://api.staging.jujucharms.com/terms/",
+		"identityURL":      "https://api.staging.jujucharms.com/identity/",
 	},
 }, {
 	about: "with qa environment",
@@ -107,6 +108,7 @@ var parseOverridesForEnvTests = []struct {
 		"charmstoreURL":    "https://www.jujugui.org/charmstore/",
 		"plansURL":         "https://www.jujugui.org/plans/",
 		"termsURL":         "https://www.jujugui.org/terms/",
+		"identityURL":      "https://www.jujugui.org/identity/",
 	},
 }, {
 	about:         "invalid environment",

--- a/internal/guiconfig/config_test.go
+++ b/internal/guiconfig/config_test.go
@@ -10,6 +10,65 @@ import (
 	it "github.com/frankban/guiproxy/internal/testing"
 )
 
+var newEnvironmentTests = []struct {
+	about          string
+	env            string
+	expectedValues map[string]interface{}
+	expectedError  error
+}{{
+	about: "production environment",
+	env:   "production",
+	expectedValues: map[string]interface{}{
+		"bundleServiceURL": "https://api.jujucharms.com/bundleservice/",
+		"charmstoreURL":    "https://api.jujucharms.com/charmstore/",
+		"plansURL":         "https://api.jujucharms.com/plans/",
+		"termsURL":         "https://api.jujucharms.com/terms/",
+	},
+}, {
+	about: "staging environment",
+	env:   "staging",
+	expectedValues: map[string]interface{}{
+		"bundleServiceURL": "https://api.staging.jujucharms.com/bundleservice/",
+		"charmstoreURL":    "https://api.staging.jujucharms.com/charmstore/",
+		"plansURL":         "https://api.staging.jujucharms.com/plans/",
+		"termsURL":         "https://api.staging.jujucharms.com/terms/",
+	},
+}, {
+	about: "qa environment",
+	env:   "qa",
+	expectedValues: map[string]interface{}{
+		"bundleServiceURL": "https://www.jujugui.org/bundleservice/",
+		"charmstoreURL":    "https://www.jujugui.org/charmstore/",
+		"plansURL":         "https://www.jujugui.org/plans/",
+		"termsURL":         "https://www.jujugui.org/terms/",
+	},
+}, {
+	about:          "none environment",
+	env:            "none",
+	expectedValues: map[string]interface{}{},
+}, {
+	about:         "invalid environment",
+	env:           "bad-wolf",
+	expectedError: errors.New(`invalid environment: "bad-wolf"`),
+}}
+
+func TestNewEnvironment(t *testing.T) {
+	for _, test := range newEnvironmentTests {
+		t.Run(test.about, func(t *testing.T) {
+			values, err := guiconfig.Environment(test.env)
+			var valuesInterfaces map[string]interface{}
+			if test.expectedValues != nil {
+				valuesInterfaces = make(map[string]interface{}, len(values))
+			}
+			for k, v := range values {
+				valuesInterfaces[k] = interface{}(v)
+			}
+			assertMap(t, valuesInterfaces, test.expectedValues)
+			it.AssertError(t, err, test.expectedError)
+		})
+	}
+}
+
 var newTests = []struct {
 	about             string
 	ctx               guiconfig.Context
@@ -82,13 +141,23 @@ func TestNew(t *testing.T) {
 	}
 }
 
-var parseOverridesTests = []struct {
+var ParseOverridesForEnvTests = []struct {
 	about             string
 	input             string
+	env               string
 	expectedOverrides map[string]interface{}
 	expectedError     error
 }{{
 	about: "no overrides",
+}, {
+	about: "with env",
+	env:   "production",
+	expectedOverrides: map[string]interface{}{
+		"bundleServiceURL": "https://api.jujucharms.com/bundleservice/",
+		"charmstoreURL":    "https://api.jujucharms.com/charmstore/",
+		"plansURL":         "https://api.jujucharms.com/plans/",
+		"termsURL":         "https://api.jujucharms.com/terms/",
+	},
 }, {
 	about: "success: single bool",
 	input: "gisf: true",
@@ -116,6 +185,10 @@ var parseOverridesTests = []struct {
 		"apiAddress": "1.2.3.4",
 		"gisf":       true,
 	},
+}, {}, {
+	about:         "failure: invalid environment",
+	env:           "bad-wolf",
+	expectedError: errors.New(`invalid environment: "bad-wolf"`),
 }, {
 	about:         "failure: invalid pairs",
 	input:         "bad, wolf",
@@ -130,17 +203,20 @@ var parseOverridesTests = []struct {
 	expectedError: errors.New("invalid value for key gisf: invalid character"),
 }}
 
-func TestParseOverrides(t *testing.T) {
-	for _, test := range parseOverridesTests {
+func TestParseOverridesForEnv(t *testing.T) {
+	for _, test := range ParseOverridesForEnvTests {
+		if test.env == "" {
+			test.env = "none"
+		}
 		t.Run(test.about, func(t *testing.T) {
-			overrides, err := guiconfig.ParseOverrides(test.input)
-			assertOverrides(t, overrides, test.expectedOverrides)
+			overrides, err := guiconfig.ParseOverridesForEnv(test.env, test.input)
+			assertMap(t, overrides, test.expectedOverrides)
 			it.AssertError(t, err, test.expectedError)
 		})
 	}
 }
 
-func assertOverrides(t *testing.T, obtained, expected map[string]interface{}) {
+func assertMap(t *testing.T, obtained, expected map[string]interface{}) {
 	o, err := json.Marshal(obtained)
 	if err != nil {
 		t.Fatalf("cannot marshal obtained overrides: %s", err)

--- a/internal/guiconfig/config_test.go
+++ b/internal/guiconfig/config_test.go
@@ -10,65 +10,6 @@ import (
 	it "github.com/frankban/guiproxy/internal/testing"
 )
 
-var newEnvironmentTests = []struct {
-	about          string
-	env            string
-	expectedValues map[string]interface{}
-	expectedError  error
-}{{
-	about: "production environment",
-	env:   "production",
-	expectedValues: map[string]interface{}{
-		"bundleServiceURL": "https://api.jujucharms.com/bundleservice/",
-		"charmstoreURL":    "https://api.jujucharms.com/charmstore/",
-		"plansURL":         "https://api.jujucharms.com/plans/",
-		"termsURL":         "https://api.jujucharms.com/terms/",
-	},
-}, {
-	about: "staging environment",
-	env:   "staging",
-	expectedValues: map[string]interface{}{
-		"bundleServiceURL": "https://api.staging.jujucharms.com/bundleservice/",
-		"charmstoreURL":    "https://api.staging.jujucharms.com/charmstore/",
-		"plansURL":         "https://api.staging.jujucharms.com/plans/",
-		"termsURL":         "https://api.staging.jujucharms.com/terms/",
-	},
-}, {
-	about: "qa environment",
-	env:   "qa",
-	expectedValues: map[string]interface{}{
-		"bundleServiceURL": "https://www.jujugui.org/bundleservice/",
-		"charmstoreURL":    "https://www.jujugui.org/charmstore/",
-		"plansURL":         "https://www.jujugui.org/plans/",
-		"termsURL":         "https://www.jujugui.org/terms/",
-	},
-}, {
-	about:          "none environment",
-	env:            "none",
-	expectedValues: map[string]interface{}{},
-}, {
-	about:         "invalid environment",
-	env:           "bad-wolf",
-	expectedError: errors.New(`invalid environment: "bad-wolf"`),
-}}
-
-func TestNewEnvironment(t *testing.T) {
-	for _, test := range newEnvironmentTests {
-		t.Run(test.about, func(t *testing.T) {
-			values, err := guiconfig.Environment(test.env)
-			var valuesInterfaces map[string]interface{}
-			if test.expectedValues != nil {
-				valuesInterfaces = make(map[string]interface{}, len(values))
-			}
-			for k, v := range values {
-				valuesInterfaces[k] = interface{}(v)
-			}
-			assertMap(t, valuesInterfaces, test.expectedValues)
-			it.AssertError(t, err, test.expectedError)
-		})
-	}
-}
-
 var newTests = []struct {
 	about             string
 	ctx               guiconfig.Context
@@ -141,7 +82,7 @@ func TestNew(t *testing.T) {
 	}
 }
 
-var ParseOverridesForEnvTests = []struct {
+var parseOverridesForEnvTests = []struct {
 	about             string
 	input             string
 	env               string
@@ -150,14 +91,27 @@ var ParseOverridesForEnvTests = []struct {
 }{{
 	about: "no overrides",
 }, {
-	about: "with env",
-	env:   "production",
+	about: "with staging env",
+	env:   "staging",
 	expectedOverrides: map[string]interface{}{
-		"bundleServiceURL": "https://api.jujucharms.com/bundleservice/",
-		"charmstoreURL":    "https://api.jujucharms.com/charmstore/",
-		"plansURL":         "https://api.jujucharms.com/plans/",
-		"termsURL":         "https://api.jujucharms.com/terms/",
+		"bundleServiceURL": "https://api.staging.jujucharms.com/bundleservice/",
+		"charmstoreURL":    "https://api.staging.jujucharms.com/charmstore/",
+		"plansURL":         "https://api.staging.jujucharms.com/plans/",
+		"termsURL":         "https://api.staging.jujucharms.com/terms/",
 	},
+}, {
+	about: "with qa environment",
+	env:   "qa",
+	expectedOverrides: map[string]interface{}{
+		"bundleServiceURL": "https://www.jujugui.org/bundleservice/",
+		"charmstoreURL":    "https://www.jujugui.org/charmstore/",
+		"plansURL":         "https://www.jujugui.org/plans/",
+		"termsURL":         "https://www.jujugui.org/terms/",
+	},
+}, {
+	about:         "invalid environment",
+	env:           "bad-wolf",
+	expectedError: errors.New(`invalid environment: "bad-wolf"`),
 }, {
 	about: "success: single bool",
 	input: "gisf: true",
@@ -204,9 +158,9 @@ var ParseOverridesForEnvTests = []struct {
 }}
 
 func TestParseOverridesForEnv(t *testing.T) {
-	for _, test := range ParseOverridesForEnvTests {
+	for _, test := range parseOverridesForEnvTests {
 		if test.env == "" {
-			test.env = "none"
+			test.env = "production"
 		}
 		t.Run(test.about, func(t *testing.T) {
 			overrides, err := guiconfig.ParseOverridesForEnv(test.env, test.input)


### PR DESCRIPTION
Test branch which allows `guiproxy -env staging` to set all of the connection URLs. These can be overwritten by passing individual flags with -config, and does not set controller info.